### PR TITLE
게임 저장 및 이어하기 기능 구현

### DIFF
--- a/public/locales/ko/game.json
+++ b/public/locales/ko/game.json
@@ -27,9 +27,27 @@
   "inventory": "소지품",
   "currency": "영석",
   "emptyInventory": "소지품이 없습니다",
+  
+  "save": "저장하기",
+  "saving": "저장 중...",
+  "saved": "저장 완료",
+  "saveError": "저장 실패",
+  "lastSaved": "마지막 저장",
+  "continueGame": "이어하기",
+  "loadingSessions": "저장된 게임 불러오는 중...",
+  "noSavedGames": "저장된 게임이 없습니다",
+  "startNewGame": "새 게임 시작",
+  "character": "캐릭터",
+  "level": "레벨",
+  "lastPlayed": "마지막 플레이",
+  "continue": "이어하기",
+  "never": "없음",
+  "noFate": "운명 없음",
+
   "errors": {
     "usernameRequired": "캐릭터 이름을 입력해주세요",
     "createGameFailed": "게임 생성에 실패했습니다",
-    "loadFateFailed": "운명 데이터를 로드하는데 실패했습니다"
+    "loadFateFailed": "운명 데이터를 로드하는데 실패했습니다",
+    "loadSessionsFailed": "저장된 게임 목록을 불러오는데 실패했습니다"
   }
 }

--- a/src/pages/api/game/list.ts
+++ b/src/pages/api/game/list.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { kv } from '@vercel/kv';
+
+interface GameSession {
+  id: string;
+  username: string;
+  lastSaved: number;
+  level?: number;
+  fate?: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    // KV 스토어에서 모든 프로필과 게임 상태 키 검색
+    const profileKeys = await kv.keys('user:*:profile');
+    
+    const sessionPromises = profileKeys.map(async (key) => {
+      // 사용자 ID 추출 (user:userId:profile 형식에서)
+      const userId = key.split(':')[1];
+      
+      // 프로필 데이터와 게임 상태 로드
+      const [profile, gameState] = await Promise.all([
+        kv.get(key),
+        kv.get(`user:${userId}:game_state`)
+      ]);
+      
+      // 게임 세션 정보 구성
+      if (profile && gameState) {
+        return {
+          id: userId,
+          username: profile.username || 'Unknown Cultivator',
+          lastSaved: gameState.lastSaved || Date.now(),
+          level: gameState.cultivation?.level || 1,
+          fate: profile.fate || gameState.fate
+        } as GameSession;
+      } else if (profile) {
+        // 게임 상태는 없지만 프로필은 있는 경우 (게임 시작 전)
+        return {
+          id: userId,
+          username: profile.username || 'Unknown Cultivator',
+          lastSaved: 0, // 아직 저장된 적 없음
+          fate: profile.fate
+        } as GameSession;
+      }
+      
+      return null;
+    });
+    
+    // 모든 세션 정보 수집
+    const sessions = (await Promise.all(sessionPromises))
+      .filter(Boolean) // 빈 세션 필터링
+      .sort((a, b) => b.lastSaved - a.lastSaved); // 최근에 저장된 순서로 정렬
+    
+    return res.status(200).json({ sessions });
+  } catch (error) {
+    console.error('Error listing game sessions:', error);
+    return res.status(500).json({ 
+      message: error instanceof Error ? error.message : 'Failed to list game sessions'
+    });
+  }
+}

--- a/src/pages/api/game/load.ts
+++ b/src/pages/api/game/load.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { kv } from '@vercel/kv';
+import { getUserProfile } from '@modules/stats/service';
+import { getUserFate } from '@modules/fate/service';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { userId } = req.query;
+
+  if (!userId || typeof userId !== 'string') {
+    return res.status(400).json({ message: 'Missing required userId parameter' });
+  }
+
+  try {
+    // 1. 저장된 게임 상태 확인
+    const gameState = await kv.get(`user:${userId}:game_state`);
+    
+    // 2. 사용자 프로필 로드
+    const profile = await getUserProfile(userId);
+    
+    if (!profile) {
+      return res.status(404).json({ message: 'User profile not found' });
+    }
+    
+    // 3. 운명 데이터 로드
+    const fateData = await getUserFate(userId);
+    
+    // 4. 응답 데이터 구성
+    // 게임 상태가 없는 경우 프로필 데이터로 기본 게임 상태 구성
+    const responseData = {
+      gameState: gameState || {
+        userId: profile.id,
+        username: profile.username,
+        age: 16, // 기본값
+        cultivation: {
+          realm: '기초 단계',
+          level: 1
+        },
+        stats: profile.stats,
+        traits: profile.traits,
+        fate: profile.fate || (fateData ? fateData.fate : undefined),
+        inventory: {
+          items: [],
+          herbs: [],
+          artifacts: [],
+          currency: 100
+        },
+        relationships: []
+      },
+      profile,
+      fateData,
+      hasSavedState: !!gameState
+    };
+    
+    return res.status(200).json(responseData);
+  } catch (error) {
+    console.error('Error loading game state:', error);
+    return res.status(500).json({ 
+      message: error instanceof Error ? error.message : 'Failed to load game state'
+    });
+  }
+}

--- a/src/pages/api/game/save.ts
+++ b/src/pages/api/game/save.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { kv } from '@vercel/kv';
+import { getUserProfile, updateUserProfile } from '@modules/stats/service';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    const { userId, gameState } = req.body;
+    
+    if (!userId || !gameState) {
+      return res.status(400).json({ message: 'Missing required fields' });
+    }
+    
+    // 사용자 프로필 업데이트 (stats, traits 등 변경 가능)
+    const profile = await getUserProfile(userId);
+    
+    if (!profile) {
+      return res.status(404).json({ message: 'User profile not found' });
+    }
+    
+    // 프로필 업데이트 데이터 준비
+    const updatedData = {
+      ...profile,
+      stats: gameState.stats || profile.stats,
+      traits: gameState.traits || profile.traits,
+      life: gameState.life !== undefined ? gameState.life : profile.life,
+      maxLife: gameState.maxLife !== undefined ? gameState.maxLife : profile.maxLife,
+    };
+    
+    // 프로필 업데이트
+    await updateUserProfile(userId, updatedData);
+    
+    // 게임 상태 저장
+    await kv.set(`user:${userId}:game_state`, {
+      ...gameState,
+      lastSaved: Date.now()
+    });
+    
+    return res.status(200).json({ 
+      success: true,
+      lastSaved: Date.now()
+    });
+  } catch (error) {
+    console.error('Error saving game state:', error);
+    return res.status(500).json({ 
+      message: error instanceof Error ? error.message : 'Failed to save game'
+    });
+  }
+}

--- a/src/pages/game/continue.tsx
+++ b/src/pages/game/continue.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect } from 'react';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import Link from 'next/link';
+
+interface GameSession {
+  id: string;
+  username: string;
+  lastSaved: number;
+  level?: number;
+  fate?: string;
+}
+
+export default function ContinueGamePage() {
+  const router = useRouter();
+  const { t } = useTranslation(['common', 'game']);
+  const [isLoading, setIsLoading] = useState(true);
+  const [sessions, setSessions] = useState<GameSession[]>([]);
+  const [error, setError] = useState('');
+
+  // 게임 세션 목록 로드
+  useEffect(() => {
+    async function loadSessions() {
+      setIsLoading(true);
+      try {
+        const response = await fetch('/api/game/list');
+        
+        if (!response.ok) {
+          throw new Error('Failed to load saved games');
+        }
+        
+        const data = await response.json();
+        setSessions(data.sessions || []);
+      } catch (err) {
+        console.error('Error loading sessions:', err);
+        setError(t('game:errors.loadSessionsFailed'));
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    loadSessions();
+  }, [t]);
+
+  // 게임 세션 선택
+  const handleSelectSession = (sessionId: string) => {
+    router.push(`/game/main?userId=${sessionId}`);
+  };
+
+  // 날짜 형식화 함수
+  const formatDate = (timestamp: number) => {
+    if (!timestamp) return t('game:never');
+    
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
+          <p>{t('game:loadingSessions')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="container mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-center mb-8">{t('game:continueGame')}</h1>
+        
+        {error && (
+          <div className="max-w-md mx-auto bg-red-900 rounded-lg p-4 mb-8 text-center">
+            <p>{error}</p>
+          </div>
+        )}
+        
+        {sessions.length === 0 ? (
+          <div className="max-w-md mx-auto bg-gray-800 rounded-lg p-6 text-center">
+            <p className="mb-6">{t('game:noSavedGames')}</p>
+            <Link
+              href="/game/new"
+              className="px-4 py-2 bg-indigo-600 rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              {t('game:startNewGame')}
+            </Link>
+          </div>
+        ) : (
+          <div className="max-w-3xl mx-auto">
+            <div className="bg-gray-800 rounded-lg overflow-hidden">
+              <table className="w-full">
+                <thead className="bg-gray-700">
+                  <tr>
+                    <th className="px-6 py-3 text-left">{t('game:character')}</th>
+                    <th className="px-6 py-3 text-left">{t('game:fate')}</th>
+                    <th className="px-6 py-3 text-left">{t('game:level')}</th>
+                    <th className="px-6 py-3 text-left">{t('game:lastPlayed')}</th>
+                    <th className="px-6 py-3 text-right">{t('game:actions')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-700">
+                  {sessions.map((session) => (
+                    <tr key={session.id} className="hover:bg-gray-700">
+                      <td className="px-6 py-4">{session.username}</td>
+                      <td className="px-6 py-4">{session.fate || t('game:noFate')}</td>
+                      <td className="px-6 py-4">{session.level || 1}</td>
+                      <td className="px-6 py-4">{formatDate(session.lastSaved)}</td>
+                      <td className="px-6 py-4 text-right">
+                        <button
+                          onClick={() => handleSelectSession(session.id)}
+                          className="px-4 py-1 bg-indigo-600 rounded hover:bg-indigo-700 transition-colors"
+                        >
+                          {t('game:continue')}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            
+            <div className="mt-8 text-center">
+              <Link href="/" className="text-indigo-400 hover:text-indigo-300 mr-4">
+                {t('game:backToHome')}
+              </Link>
+              <Link href="/game/new" className="text-indigo-400 hover:text-indigo-300">
+                {t('game:startNewGame')}
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale || 'ko', ['common', 'game'])),
+    },
+  };
+};


### PR DESCRIPTION
## 게임 저장 및 이어하기 기능 구현

게임 상태가 저장되지 않고 이어하기가 불가능했던 문제를 해결했습니다. 주요 개선 사항은 다음과 같습니다:

### 추가된 API 엔드포인트
- `/api/game/save`: 현재 게임 상태를 저장하는 API를 추가했습니다.
- `/api/game/load`: 저장된 게임 상태를 불러오는 API를 추가했습니다.
- `/api/game/list`: 저장된 게임 세션 목록을 불러오는 API를 추가했습니다.

### UI 개선
- 게임 메인 페이지(`/game/main.tsx`)에 저장 버튼과 자동 저장 기능을 추가했습니다.
- 이어하기 페이지(`/game/continue.tsx`)를 추가하여 저장된 게임 목록을 보고 선택할 수 있게 했습니다.

### 국제화
- 게임 저장 및 이어하기 관련 국제화 키를 추가했습니다.

이 변경사항으로 인해 사용자는 이제 게임 상태를 저장하고 나중에 이어서 게임을 할 수 있습니다. 게임 상태는 5분마다 자동으로 저장되며, 언제든지 수동으로 저장할 수도 있습니다.
